### PR TITLE
feat: adds dependency inversion for CepService

### DIFF
--- a/CepService.php
+++ b/CepService.php
@@ -1,10 +1,6 @@
 <?php 
 
-class CepService
+interface CepService 
 {
-    public function buscarCep(string $cep): string
-    {
-        // Faria a consulta na API externa e retornaria o endereço
-        return 'Rua Alegre, 123 - São Paulo - SP';
-    }
+    public function buscarCep(string $cep): string;
 }

--- a/CepServiceFake.php
+++ b/CepServiceFake.php
@@ -1,0 +1,11 @@
+<?php 
+require_once __DIR__ . '/CepService.php';
+
+class CepServiceFake implements CepService
+{
+    public function buscarCep(string $cep): string
+    {
+        // Faria a consulta na API externa e retornaria o endereço
+        return 'Rua Triste, 321 - São Paulo - SP';
+    }
+}

--- a/CepServiceReal.php
+++ b/CepServiceReal.php
@@ -1,0 +1,12 @@
+<?php 
+require_once __DIR__ . '/CepService.php';
+
+class CepServiceReal implements CepService
+{
+    public function buscarCep(string $cep): string
+    {
+        // Faria a consulta na API externa e retornaria o endereço
+        sleep(5);
+        return 'Rua Alegre, 123 - São Paulo - SP';
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,14 +1,17 @@
 <?php 
 
 require_once __DIR__ . '/Cliente.php';
-require_once __DIR__ . '/CepService.php';
+require_once __DIR__ . '/CepServiceReal.php';
+require_once __DIR__ . '/CepServiceFake.php';
 
 
 require_once __DIR__ . '/Produto.php';
 require_once __DIR__ . '/PDFGenerator.php';
 require_once __DIR__ . '/XLSGenerator.php';
 
-echo (new Cliente(new CepService))->cadastrar();
+echo (new Cliente(new CepServiceFake))->cadastrar();
+echo '<br>';
+echo (new Cliente(new CepServiceReal))->cadastrar();
 echo '<br>';
 echo (new Produto(new PDFGenerator))->gerarRelatorio();
 echo '<br>';


### PR DESCRIPTION
A inversão de dependência facilita os testes.

Exemplo:

Uma situação que preciso que a minha classe de Cliente consulte uma API externa para retornar o CEP, e quero testar essa classe cliente, mas suponha que levaria cinco segundos para fazer esse teste com a classe real que faz essa consulta, o que geraria uma espera considerável para se escrever um case de teste simples. Para contornar essa situação, eu posso utilizar o conceito de inversão de dependência, fazendo com que a minha classe de Cliente no lugar de depender da classe concreta de CEP passe a depender de uma abstração, ou seja, uma interface. Dessa forma poderei injetar uma classe fake na minha classe de Cliente quando for desenvolver o script de teste, nessa classe fake o método de consultar o CEP me retornará um dado fixo, fazendo com que não seja gasto o tempo de cinco segundos.